### PR TITLE
lschub - added runtime analysis and commented out debug lines

### DIFF
--- a/Days/1/levi-schubert/part1/src/main.rs
+++ b/Days/1/levi-schubert/part1/src/main.rs
@@ -1,13 +1,15 @@
 use std::fs;
 use std::error::Error;
+use std::time::SystemTime;
 
 
 fn main() -> Result<(), Box<dyn Error>>{
+    let start_time = SystemTime::now();
     let input: String = fs::read_to_string("input/input.txt")?.parse()?;
     let lines: Vec<&str> = input.split("\r\n").collect();
     let mut sum = 0;
 
-    let mut line_count = 1;
+    //let mut line_count = 1;
 
     for line in &lines {
         let mut num_index1 = 0;
@@ -31,12 +33,13 @@ fn main() -> Result<(), Box<dyn Error>>{
             num_index2 = num_index1
         }
         let num = line.chars().nth(num_index1).unwrap().to_string() + &line.chars().nth(num_index2).unwrap().to_string();
-        println!("line: {}, num: {:?}", line_count, num);
+        //println!("line: {}, num: {:?}", line_count, num);
         sum += num.parse::<usize>().unwrap();
-        line_count += 1;
+        //line_count += 1;
     }
-
-    println!("{}", sum);
+    let end_time = SystemTime::now();
+    let time_taken = end_time.duration_since(start_time).expect("Clock may have gone backwards");
+    println!("sum: {} \ntime taken: {:?}", sum, time_taken);
     Ok(())
 }
 

--- a/Days/1/levi-schubert/part2/src/main.rs
+++ b/Days/1/levi-schubert/part2/src/main.rs
@@ -1,14 +1,16 @@
 use std::cmp::Ordering;
 use std::fs;
 use std::error::Error;
+use std::time::SystemTime;
 
 
 fn main() -> Result<(), Box<dyn Error>>{
+    let start_time = SystemTime::now();
     let input: String = fs::read_to_string("input/input.txt")?.parse()?;
     let lines: Vec<&str> = input.split("\r\n").collect();
     let mut sum = 0;
 
-    let mut line_count = 1;
+    //let mut line_count = 1;
 
     for line in &lines {
         let _num_index1 = 0;
@@ -17,7 +19,7 @@ fn main() -> Result<(), Box<dyn Error>>{
         let _num_two_set = false;
         let mut count = 0;
         let mut nums = get_word_nums(line);
-        println!("{:?}", line);
+        //println!("{:?}", line);
         for c in line.chars(){
             if c.is_numeric() {
                 let num_index = NumIndex{
@@ -31,15 +33,16 @@ fn main() -> Result<(), Box<dyn Error>>{
         nums.sort_by(|one, two| one.cmp(two));
         let letter1 = nums[0].num.to_string();
         let letter2 = nums[nums.len()-1].num.to_string();
-        println!("nums: {:?}", nums);
+        //println!("nums: {:?}", nums);
 
         let num = letter1.to_string() + &letter2.to_string();
-        println!("line: {}, num: {:?}", line_count, num);
+        //println!("line: {}, num: {:?}", line_count, num);
         sum += num.parse::<usize>().unwrap();
-        line_count += 1;
+        //line_count += 1;
     }
-
-    println!("sum: {}", sum);
+    let end_time = SystemTime::now();
+    let time_taken = end_time.duration_since(start_time).expect("Clock may have gone backwards");
+    println!("sum: {} \ntime taken: {:?}", sum, time_taken);
     Ok(())
 }
 

--- a/templates/levi-schubert/rust_template/src/main.rs
+++ b/templates/levi-schubert/rust_template/src/main.rs
@@ -1,9 +1,16 @@
 use std::fs;
 use std::error::Error;
-
+use std::time::SystemTime;
 
 fn main() -> Result<(), Box<dyn Error>>{
+    let start_time = SystemTime::now();
+    let mut answer = "";
     let input: String = fs::read_to_string("input/input.txt")?.parse()?;
     println!("{}", input);
+
+
+    let end_time = SystemTime::now();
+    let time_taken = end_time.duration_since(start_time).expect("Clock may have gone backwards");
+    println!("answer: {} \ntime taken: {:?}", answer, time_taken);
     Ok(())
 }


### PR DESCRIPTION
# Day one puzzle solution benchmarks
## Part one run times:
* 5.4095ms
* 4.7428ms
* 5.6124ms
* 4.683ms
* 4.8121ms
**The avg of part one elements is : 5.05196ms**

## Part two run times:
* 12.3141ms
* 10.8875ms
* 12.2665ms
* 11.2968ms
* 11.1063ms
**The avg of part two elements is : 11.57424ms**

and because comedy comes in threes:
![otwinuxa4pv81](https://github.com/CtrlVaultDel/AdventOfCode2023/assets/35117077/ed478afb-fb1a-4177-a77e-05ba339b9936)
